### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+.gitattributes export-ignore
+.github/ export-ignore
+.gitignore export-ignore
+.pyspelling.yml export-ignore
+.travis.yml export-ignore
+docs/ export-ignore
+mkdocs.yml export-ignore
+tests/ export-ignore
+tox.ini export-ignore


### PR DESCRIPTION
## Description

Exclude non-productional files/dirs from the downloaded package via Package Control. Especially, `docs/` which contains large image files.