### PR TITLE
Fix py38 syntax error

### DIFF
--- a/find_cursor.py
+++ b/find_cursor.py
@@ -48,7 +48,7 @@ FORWARD = 1
 BACKWARD = -1
 
 
-class PanCursor(namedtuple('PanCursor', ['cursor', 'distance', 'index'], verbose=False)):
+class PanCursor(namedtuple('PanCursor', ['cursor', 'distance', 'index'])):
     """Pan cursor object."""
 
     pass


### PR DESCRIPTION
ST 4193 introduces a new setting:

- Added <tt>"disable_plugin_host_3.3"</tt> setting. This causes all plugins to run under 3.8

While running this plugin under python 3.8, this plugin failed due to a unknown kwarg error of `verbose`.

---

According to [py33 docs](https://docs.python.org/3.3/library/collections.html#namedtuple-factory-function-for-tuples-with-named-fields), "verbose" is already `False` by default.

And according to [py38 docs](https://docs.python.org/3.8/library/collections.html#namedtuple-factory-function-for-tuples-with-named-fields), "verbose" is removed in py37. This make it a unknown kwarg error in py38.

Thus, my suggested change is we just remove the "verbose" kwarg because it's not necessary both in py33 and py38.
